### PR TITLE
Add try-catch in case that it is unable to invite a guest user

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -48,7 +48,7 @@ function invite(event, guestId){
     event.addGuest(guestId);
     Logger.log('Invited: ' + event.getTitle() + ' (' + event.getStartTime() + ')');
   } catch (e) {
-    Logger.log('*** Failed to invite guest user: ' + e.message);
+    Logger.log('*** Failed to invite guest user >> Event Title: ' + event.getTitle() + ' | Error message:' + e.message);
   }
 }
 

--- a/Code.js
+++ b/Code.js
@@ -44,8 +44,12 @@ function syncStatus(event, guest){
 }
 
 function invite(event, guestId){
-  event.addGuest(guestId);
-  Logger.log('Invited: ' + event.getTitle() + ' (' + event.getStartTime() + ')');
+  try {
+    event.addGuest(guestId);
+    Logger.log('Invited: ' + event.getTitle() + ' (' + event.getStartTime() + ')');
+  } catch (e) {
+    Logger.log('*** Failed to invite guest user: ' + e.message);
+  }
 }
 
 function notify(message){


### PR DESCRIPTION
# What
Add try-catch in case that it is unable to invite a guest user

# Why
- Sometimes some events don't allow guests to invite other guests.
- However, this script has no error handling section.
- So this script always exits in the middle of running if it was unable to invite guests.
<img width="1185" alt="Screenshot at Apr 07 05-21-09" src="https://github.com/soetani/gas-sync-google-calendar/assets/93567726/a92f0d00-ede9-4eae-9dd7-a333eaa2bbc9">
