### PR TITLE
Introduce version 2

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -1,63 +1,134 @@
-// README
-// Instruction: https://github.com/soetani/gas-sync-google-calendar
-// 1. How many days do you want to sync your calendars?
-var DAYS_TO_SYNC = 30;
-// 2. Calendar ID mapping: [Calendar ID (Source), Calendar ID (Guest)]
-var CALENDAR_IDS = [
-  ['source_01@example.com', 'guest_01@example.net'],
-  ['source_02@example.com', 'guest_02@example.net']
-];
-// 3. What is Slack webhook URL? You'll be notified when the sync is failed
-var SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/foobar';
+// README https://github.com/soetani/gas-sync-google-calendar
+// [REQUIRED] Email address of the calendar which can be managed by your Google account. 
+//            No modification needed to sync with your default calendar.
+const HOST_ID = CalendarApp.getDefaultCalendar().getId();
+// [REQUIRED] Array of email address(es) to sync with your calendar 
+const GUEST_IDS = ['my-second-account@example.com'];
+// [REQUIRED] Date range to sync calendar. When MIN is -1 and MAX is 30, they mean events from yesterday to 30 days from today will be synced.
+const MIN_SYNC_DATE = getRelativeDate(-1);
+const MAX_SYNC_DATE = getRelativeDate(60);
+// [OPTIONAL] Slack Incoming Webhook to notify warnings to Slack channel. If empty, warnings to be notified to your email address
+const SLACK_INCOMING_WEBHOOK = '';
+// [DO NOT UPDATE]
+const CALENDAR_IDS = [HOST_ID, GUEST_IDS].flat();
 
-function main(){
-  var dateFrom = new Date();
-  var dateTo = new Date(dateFrom.getTime() + (DAYS_TO_SYNC * 24 * 60 * 60* 1000));
-  
-  CALENDAR_IDS.forEach(function(ids){
-    var sourceId = ids[0];
-    var guestId = ids[1];
-    Logger.log('Source: ' + sourceId + ' / Guest: ' + guestId);
-    
-    var events = CalendarApp.getCalendarById(sourceId).getEvents(dateFrom, dateTo);
-    events.forEach(function(event){
-      var guest = event.getGuestByEmail(guestId);
-      guest ? syncStatus(event, guest) : invite(event, guestId);
+function init() {
+  ScriptApp.getProjectTriggers().forEach(trigger => ScriptApp.deleteTrigger(trigger));
+  fullSync();
+  ScriptApp.newTrigger('sync').timeBased().everyMinutes(5).create();
+}
+
+function fullSync() {
+  PropertiesService.getUserProperties().deleteProperty('syncToken');
+  sync();
+}
+
+function sync() {
+  const properties = PropertiesService.getUserProperties();
+  const syncToken = properties.getProperty('syncToken');
+  let events;
+  let pageToken;
+
+  const options = { maxResults: 100 };
+  if (syncToken) options.syncToken = syncToken;
+  else options.timeMin = MIN_SYNC_DATE.toISOString();
+
+  do {
+    try {
+      options.pageToken = pageToken;
+      events = Calendar.Events.list(HOST_ID, options);
+    } catch (e) {
+      if (e.message === 'Sync token is no longer valid, a full sync is required.') {
+        fullSync();
+        return;
+      } else {
+        throw new Error(e.message);
+      }
+    }
+
+    if (events.items && events.items.length > 0) events.items.forEach(event => syncEvent(event));
+    pageToken = events.nextPageToken;
+  } while (pageToken);
+
+  properties.setProperty('syncToken', events.nextSyncToken);
+}
+
+function getRelativeDate(daysOffset) {
+  let date = new Date();
+  date.setDate(date.getDate() + daysOffset);
+  return date;
+}
+
+function syncEvent(event) {
+  if (event.status === 'cancelled' || event.eventType !== 'default') return;
+  const start = event.start.date ? new Date(event.start.date) : new Date(event.start.dateTime);
+  if (start < MIN_SYNC_DATE || start > MAX_SYNC_DATE) return;
+  const attendeesInvited = inviteAttendees(event);
+  const responseStatusSynced = syncResponseStatus(event);
+  if (attendeesInvited || responseStatusSynced) Calendar.Events.update(event, HOST_ID, event.id);
+}
+
+// Add attendee(s) to the event when needed. Return true when the event is modified
+function inviteAttendees(event) {
+  if (!event.attendees) {
+    event.attendees = GUEST_IDS.map(email => ({ email: email }));
+    if (event.organizer.email === HOST_ID) event.attendees.push({ email: HOST_ID, responseStatus: 'accepted' });
+    else event.attendees.push({ email: HOST_ID });
+
+    Logger.log(`Inviting attendee(s): ${getSummaryForLog(event)}`);
+    return true; // Event is modified 
+  }
+
+  const attendeesEmailArray = event.attendees.map(attendees => attendees.email);
+  const additionalAttendees = CALENDAR_IDS.filter(email => !attendeesEmailArray.includes(email)).map(email => ({ email: email }));
+  if (additionalAttendees.length > 0) {
+    event.attendees = event.attendees.concat(additionalAttendees);
+    Logger.log(`Inviting attendee(s): ${getSummaryForLog(event)}`);
+    return true; // Event is modified
+  }
+
+  Logger.log(`No invitation needed: ${getSummaryForLog(event)}`);
+  return false; // Event is not modified
+}
+
+// Sync status of the event when needed. Return true when the event is modified
+function syncResponseStatus(event) {
+  const attendeesStatus = event.attendees.filter(attendee => (
+    GUEST_IDS.includes(attendee.email) && attendee.responseStatus && attendee.responseStatus !== 'needsAction'
+  )).map(attendee => attendee.responseStatus);
+  const myStatus = event.attendees.filter(attendee => attendee.email === HOST_ID)[0].responseStatus;
+  const isAllStatusEqual = attendeesStatus.every(status => status === attendeesStatus[0]);
+
+  if (attendeesStatus.length > 0 && isAllStatusEqual && (myStatus === 'needsAction' || !myStatus)) {
+    event.attendees = event.attendees.map(attendee => {
+      if (attendee.email === HOST_ID) attendee.responseStatus = attendeesStatus[0];
+      return attendee;
     });
-  });
+    Logger.log(`Syncing status: ${getSummaryForLog(event)}`);
+    return true; // Event is modified
+  } else if (!isAllStatusEqual || (attendeesStatus.length > 0 && attendeesStatus[0] !== myStatus)) {
+    warn(`Calendar sync failed: ${getSummaryForLog(event)}`);
+    Logger.log(`Syncing status failed: ${getSummaryForLog(event)}`);
+  } else {
+    Logger.log(`Status already synced: ${getSummaryForLog(event)}`);
+  }
+  return false; // Event is not mofidied
 }
 
-function syncStatus(event, guest){
-  var sourceStatus = event.getMyStatus();
-  var guestStatus = guest.getGuestStatus();
-  
-  if(guestStatus != CalendarApp.GuestStatus.YES && guestStatus != CalendarApp.GuestStatus.NO) return;
-  if((sourceStatus == CalendarApp.GuestStatus.YES || sourceStatus == CalendarApp.GuestStatus.NO) && sourceStatus != guestStatus){
-    // Notify when source status is opposite from guest's status
-    notify('Failed to sync the status of the event: ' + event.getTitle() + ' (' + event.getStartTime() + ')');
-  }
-  else if(sourceStatus != guestStatus && sourceStatus != CalendarApp.GuestStatus.OWNER){
-    // Update status when my status is invited/maybe AND guest's status is yes/no
-    event.setMyStatus(guestStatus);
-    Logger.log('Status updated:' + event.getTitle() + ' (' + event.getStartTime() + ')');
-  }
+function getSummaryForLog(event) {
+  let start = event.start.date ? new Date(event.start.date).toLocaleDateString() : new Date(event.start.dateTime).toLocaleString();
+  return `${event.summary} (${start})`;
 }
 
-function invite(event, guestId){
-  try {
-    event.addGuest(guestId);
-    Logger.log('Invited: ' + event.getTitle() + ' (' + event.getStartTime() + ')');
-  } catch (e) {
-    Logger.log('*** Failed to invite guest user >> Event Title: ' + event.getTitle() + ' | Error message:' + e.message);
+function warn(message) {
+  if (SLACK_INCOMING_WEBHOOK) {
+    // Send message to Slack if webhook is provided
+    const data = { text: `Warning: ${message}` };
+    const options = { method: 'post', contentType: 'application/json', payload: JSON.stringify(data) };
+    UrlFetchApp.fetch(SLACK_INCOMING_WEBHOOK, options);
+  } else {
+    // Send email if webhook is not provided
+    const email = CalendarApp.getDefaultCalendar().getId();
+    GmailApp.sendEmail(email, 'Warning: Google Calendar Sync', `Warning: ${message}`);
   }
-}
-
-function notify(message){
-  var data = {'text': message};
-  var options = {
-    'method': 'post',
-    'contentType': 'application/json',
-    'payload': JSON.stringify(data)
-  };
-  UrlFetchApp.fetch(SLACK_WEBHOOK_URL, options);
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Shota Soetani
+Copyright (c) 2024 Shota Soetani
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Google Apps Script to sync Google Calendar
+# Google Apps Script to Sync Google Calendar
 
 ## What's this?
 
-This GAS is allow you to sync events of Google Calendar.
+This GAS allows you to sync events of Google Calendar.
 
 e.g. You have `a@gmail.com` and `b@gmail.com`
 
@@ -10,36 +10,32 @@ e.g. You have `a@gmail.com` and `b@gmail.com`
 
 - Fetch events of `a@gmail.com`
 - Check guests of each event
-- If `b@gmail.com` is not invited for the event, the script invites `b@gmail.com`
-- If `b@gmail.com` is already invited and set YES/NO status, the script updates status of `a@gmail.com`
-- If `a@gamil.com` and `b@gmail.com` have opposite status, the script notifies to Slack
+- If `b@gmail.com` is not invited to the event, the script invites `b@gmail.com`
+- If `b@gmail.com` is already invited and has set a YES/NO status, the script updates the status of `a@gmail.com`
+- If `a@gmail.com` and `b@gmail.com` have opposite statuses, the script notifies Slack
 
 **`b@gmail.com`**
 
 - Fetch events of `b@gmail.com`
 - Check guests of each event
-- If `a@gmail.com` is not invited for the event, the script invites `a@gmail.com`
-- If `a@gmail.com` is already invited and set YES/NO status, the script updates status of `b@gmail.com`
-- If `a@gamil.com` and `b@gmail.com` have opposite status, the script notifies to Slack
+- If `a@gmail.com` is not invited to the event, the script invites `a@gmail.com`
+- If `a@gmail.com` is already invited and has set a YES/NO status, the script updates the status of `b@gmail.com`
+- If `a@gmail.com` and `b@gmail.com` have opposite statuses, the script notifies Slack
 
 ## How to use
 
-**IT IS REQUIRED TO EXECUTE SCRIPT ON BOTH ACCOUNTS TO SYNC EVENTS.**
+**IT IS REQUIRED TO EXECUTE THE SCRIPT ON BOTH ACCOUNTS TO SYNC EVENTS.**
 
-### Set up variables
+### Set up a variable
 
-To execute the GAS, please configure three variables.
+To execute the GAS, please configure `GUEST_IDS`.
 
-- `DAYS_TO_SYNC`: To sync events 30 days from now, please set 30.
-- `CALENDAR_IDS`: Email address mapping of source calendar ID and guest calendar ID
-- `SLACK_WEBHOOK_URL`: There is something wrong, error will be notified to this Slack channel.
+- `GUEST_IDS`: Email address(es) that you want to invite as guests for your events.
 
-### Set up trigger
+### Add Calendar Service
 
-To execute the GAS automatically, please set up the trigger
+Click `Services` on the sidebar of the Google Apps Script Editor, and add `Google Calendar API (Version v3)`.
 
-`Edit > Current project triggers`
+### Initialize Script
 
-- Run: `main`
-- Events: `Time-driven`
-
+You may simply run the `init` method from the editor. It will sync your calendar and create a trigger that runs the script every 5 minutes.

--- a/appsscript.json
+++ b/appsscript.json
@@ -1,6 +1,13 @@
 {
-  "timeZone": "Asia/Bangkok",
   "dependencies": {
+    "enabledAdvancedServices": [
+      {
+        "userSymbol": "Calendar",
+        "version": "v3",
+        "serviceId": "calendar"
+      }
+    ]
   },
-  "exceptionLogging": "STACKDRIVER"
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8"
 }


### PR DESCRIPTION
6年ぶりにアップデート

What's new
- Google Calendarのイベント取得方法を対象の全件取得から、前回取得時より変更があったものに限定することで実行時間を短縮
- Slack Webhookを任意に（設定されていない場合は実行アカウント宛にメールでエラー通知）
- Script中に記載すべきメールアドレスは同期先のアドレスのみに（同期元のアドレス `HOST_ID` は `CalendarApp.getDefaultCalendar().getId();` で取得）
- 繰り返し実行するトリガーの設定および初回同期を行う `init` 関数の新設