### PR TITLE
Support for changing error messages for invalid tokens

### DIFF
--- a/Code.js
+++ b/Code.js
@@ -38,7 +38,7 @@ function sync() {
       options.pageToken = pageToken;
       events = Calendar.Events.list(HOST_ID, options);
     } catch (e) {
-      if (e.message === 'Sync token is no longer valid, a full sync is required.') {
+      if (e.message.includes('Sync token is no longer valid, a full sync is required.')) {
         fullSync();
         return;
       } else {


### PR DESCRIPTION
## Why this PR is needed
The error message for invalid tokens has changed so when the token is invalid, fullSync is not called.

![image](https://github.com/user-attachments/assets/0029394b-d112-4867-b40a-4cc91ec15990)

## What I did in this PR
Use the method of "includes" to support for additional error messages

## Checklist
- [x] Test has succeeded